### PR TITLE
Fixed port variable

### DIFF
--- a/src/PSSparseServerTask.cpp
+++ b/src/PSSparseServerTask.cpp
@@ -502,17 +502,17 @@ void PSSparseServerTask::main_poll_thread_fn(int poll_id) {
     struct sockaddr_in serv_addr;
     serv_addr.sin_family = AF_INET;
     serv_addr.sin_addr.s_addr = INADDR_ANY;
-    serv_addr.sin_port = htons(port_);
+    serv_addr.sin_port = htons(ps_port);
     std::memset(serv_addr.sin_zero, 0, sizeof(serv_addr.sin_zero));
 
     int ret = bind(server_sock_,
             reinterpret_cast<sockaddr*> (&serv_addr), sizeof(serv_addr));
     if (ret < 0) {
-      throw std::runtime_error("Error binding in port " + to_string(port_));
+      throw std::runtime_error("Error binding in port " + to_string(ps_port));
     }
 
     if (listen(server_sock_, SOMAXCONN) == -1) {
-      throw std::runtime_error("Error listening on port " + to_string(port_));
+      throw std::runtime_error("Error listening on port " + to_string(ps_port));
     }
     fdses[0].at(0).fd = server_sock_;
     fdses[0].at(0).events = POLLIN;

--- a/src/Tasks.h
+++ b/src/Tasks.h
@@ -328,7 +328,6 @@ class PSSparseServerTask : public MLTask {
   // file descriptors for pipes
   int pipefds[NUM_POLL_THREADS][2] = {{0}};
 
-  int port_ = 1337;               //< server port
   int server_sock_ = 0;           //< server used to receive connections
   const uint64_t max_fds = 1000;  //< max number of connections supported
   int timeout = 1;                //< 1 ms


### PR DESCRIPTION
port_ is set to 1337, which always initializes the PS to port 1337. 

Instead of setting port_ I deleted it because it is only used once, and PSSparseServerTask is a subclass of MLTask, which already contains a variable called ps_port, which is set properly. 