### PR TITLE
Fix num_jobs higher than len(cirrus_jobs) bug

### DIFF
--- a/python/frontend/cirrus/cirrus/GridSearch.py
+++ b/python/frontend/cirrus/cirrus/GridSearch.py
@@ -39,6 +39,12 @@ class GridSearch:
                 hyper_params=hyper_params,
                 machines=machines)
 
+        adjust_num_threads();
+
+    def adjust_num_threads(self):
+        # make sure we don't have more threads than experiments
+        self.num_jobs = min(self.num_jobs, len(self.cirrus_objs))
+
 
     # User must either specify param_dict_lst, or hyper_vars, hyper_params, and param_base
     def set_task_parameters(self, task, param_base=None, hyper_vars=[], hyper_params=[], machines=[]):
@@ -193,6 +199,8 @@ class GridSearch:
 
     def set_threads(self, n):
         self.num_jobs = n
+
+        adjust_num_threads();
 
 
     # Start threads to maintain all experiments


### PR DESCRIPTION
Fixes bug when number of threads is higher than number of experiments to run.

Happens with code:

```
gs = cirrus.GridSearch(task=cirrus.LogisticRegression,
                           param_base=basic_params,
                           hyper_vars=["learning_rate"],
                           hyper_params=[[0.1]],
                           machines=[(url, ip)])
gs.set_threads(2)
gs.run(UI=True)
```

I think an easier design would have been to create a queue of jobs to be checked (loss, etc..) and then have consumers threads getting from the front of the queue and pushing back to the end when done. 

This results in:

```
Exception in thread Thread-7:
Traceback (most recent call last):
  File "/usr/lib/python2.7/threading.py", line 801, in __bootstrap_inner
    self.run()
  File "/usr/lib/python2.7/threading.py", line 754, in run
    self.__target(*self.__args, **self.__kwargs)
  File "/home/joao/Documents/repos/cirrus/python/frontend/cirrus/cirrus/GridSearch.py", line 133, in custodian
    cirrus_obj = cirrus_objs[index]
IndexError: list index out of range
```


@andrewmzhang 

