### PR TITLE
Small refactoring

### DIFF
--- a/src/SparseLRModel.cpp
+++ b/src/SparseLRModel.cpp
@@ -407,7 +407,7 @@ void SparseLRModel::ensure_preallocated_vectors(const Configuration& config) con
   
   // value needs to be less than number of samples in minibatch
   if (part2.capacity() == 0) {
-    part2.resize(500);
+    part2.resize(config.get_minibatch_size());
   }
 }
 


### PR DESCRIPTION
This makes the size of ```part2``` dependent on the minibatch size -- the way it should be.